### PR TITLE
Closes #16 Cannot install on windows - Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ macOS:
 brew install pkg-config poppler
 ```
 
+Windows:
+Install Build Tools for Microsoft Visual Studio C++
+Install poppler through conda:
+```
+conda install poppler
+```
+
 Conda users may also need `libgcc`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ macOS:
 brew install pkg-config poppler
 ```
 
+Conda users may also need `libgcc`:
+
+```
+conda install libgcc
+```
+
 Windows:
 
 Install Build Tools for Microsoft Visual Studio C++
@@ -64,11 +70,6 @@ Install poppler through conda:
 conda install poppler
 ```
 
-Conda users may also need `libgcc`:
-
-```
-conda install libgcc
-```
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ brew install pkg-config poppler
 ```
 
 Windows:
+
 Install Build Tools for Microsoft Visual Studio C++
+
 Install poppler through conda:
 ```
 conda install poppler

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,13 @@ if platform.system() in ["Darwin", "FreeBSD", "OpenBSD"]:
     include_dirs = ["/usr/local/include"]
     library_dirs = ["/usr/local/lib"]
 elif platform.system() in ['Windows']:
-    conda_dir = os.getenv('CONDA_PREFIX')
+    conda_dir = getenv('CONDA_PREFIX')
     if conda_dir is None:
         print("ERROR: CONDA_PREFIX is not found.")
         print("       Install Anaconda or fix missing CONDA_PREFIX and try again.")
         sys.exit(1)
-    anaconda_poppler_include_dir = os.path.join(conda_dir, 'Library\include')
-    anaconda_poppler_library_dir = os.path.join(conda_dir, 'Library\lib')
+    anaconda_poppler_include_dir = path.join(conda_dir, 'Library\include')
+    anaconda_poppler_library_dir = path.join(conda_dir, 'Library\lib')
     include_dirs = [anaconda_poppler_include_dir]
     library_dirs = [anaconda_poppler_library_dir]
 else:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import platform
 import subprocess
+import sys
+from os import getenv, path
 from setuptools import Extension
 from setuptools import setup
 
@@ -21,6 +23,16 @@ def poppler_cpp_at_least(version):
 if platform.system() in ["Darwin", "FreeBSD", "OpenBSD"]:
     include_dirs = ["/usr/local/include"]
     library_dirs = ["/usr/local/lib"]
+elif platform.system() in ['Windows']:
+    conda_dir = os.getenv('CONDA_PREFIX')
+    if conda_dir is None:
+        print("ERROR: CONDA_PREFIX is not found.")
+        print("       Install Anaconda or fix missing CONDA_PREFIX and try again.")
+        sys.exit(1)
+    anaconda_poppler_include_dir = os.path.join(conda_dir, 'Library\include')
+    anaconda_poppler_library_dir = os.path.join(conda_dir, 'Library\lib')
+    include_dirs = [anaconda_poppler_include_dir]
+    library_dirs = [anaconda_poppler_library_dir]
 else:
     include_dirs = None
     library_dirs = None


### PR DESCRIPTION
Fixes issue where install looks for poppler lib and include in different directory than Anaconda installed it. 
Updates readme with install instructions for Windows. 