### PR TITLE
:pencil: Updating the Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ print("\n\n".join(pdf))
 ## OS Dependencies
 
 ### Debian, Ubuntu, and friends
-
+for python3
+```raw
+sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python3-dev
+```
+for python2
 ```
 sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python-dev
 ```


### PR DESCRIPTION
Updated the document, as given Dependency installation for `Debian, Ubuntu, and friends` install dev package for `python2`. Copying that line didn't resolve installation issues for  `pdftotext` in `python3`. The updated line did. :) 