### PR TITLE
Add brew support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.o
 *.pyc
 *.so
+venv


### PR DESCRIPTION
* Adds support for getting the poppler include and library directories from brew directly
* Useful in M1 Mac's, where the homebrew prefix is non standard due to the separation of intel libraries and arm libraries
* To support both python 2 and 3 `check_output` is decoded, in python 3 this is a byte whereas in python 2 it is a string already