### PR TITLE
setup.py: handle missing brew command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def brew_poppler_include():
             elif brew_file.endswith(".dylib"):
                 library_dir = os.path.dirname(brew_file)
         return include_dir, library_dir
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         return None, None
 
 


### PR DESCRIPTION
The `brew` command may not be present in PATH. Catch the `OSError` exception thrown when that's the case.

Closes #95.

Related: https://github.com/NixOS/nixpkgs/pull/146519